### PR TITLE
Fix bug about Phalcon\Paginator\Adapter\QueryBuilder

### DIFF
--- a/ext/kernel/memory.c
+++ b/ext/kernel/memory.c
@@ -87,6 +87,7 @@ void phalcon_initialize_memory(zend_phalcon_globals *phalcon_globals_ptr TSRMLS_
 	/* 'Allocator sizeof operand mismatch' warning can be safely ignored */
 	ALLOC_INIT_ZVAL(phalcon_globals_ptr->z_null);
 	Z_SET_REFCOUNT_P(phalcon_globals_ptr->z_null, 2);
+	ZVAL_NULL(phalcon_globals_ptr->z_null);
 
 	/* 'Allocator sizeof operand mismatch' warning can be safely ignored */
 	ALLOC_INIT_ZVAL(phalcon_globals_ptr->z_false);

--- a/ext/paginator/adapter/querybuilder.c
+++ b/ext/paginator/adapter/querybuilder.c
@@ -244,7 +244,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, getPaginate){
 	zval *models = NULL, *model_name = NULL, *model = NULL, *connection = NULL;
 	zval *bind_params = NULL, *bind_types = NULL, *processed = NULL;
 	zval *value = NULL, *wildcard = NULL, *string_wildcard = NULL, *processed_types = NULL;
-	zval *intermediate = NULL, *columns, *type = NULL, *column = NULL, *sql_column = NULL;
+	zval *intermediate = NULL, *columns, *select_columns, *type = NULL, *column = NULL, *sql_column = NULL;
 	zval *dialect = NULL, *sql_select = NULL, *sql, *sql_tmp = NULL;
 	zval *paginate;
 	HashTable *ah0, *ah1, *ah2;
@@ -360,15 +360,15 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, getPaginate){
 		 * Complete objects are treated in a different way
 		 */
 		if (PHALCON_IS_STRING(type, "object")) {
-			PHALCON_OBS_NVAR(columns);
-			ZVAL_STRING(columns, "*", 1);
+			PHALCON_INIT_VAR(select_columns);
+			ZVAL_STRING(select_columns, "*", 1);
+
+			phalcon_array_update_string(&intermediate, ISL(columns), select_columns, PH_COPY);
 			break;
 		}
 
 		zend_hash_move_forward_ex(ah0, &hp0);
 	}
-
-	phalcon_array_update_string(&intermediate, ISL(column), columns, PH_COPY);
 
 	PHALCON_CALL_METHOD(&dialect, connection, "getdialect");
 	PHALCON_CALL_METHOD(&sql_select, dialect, "select", intermediate);

--- a/ext/phalcon.c
+++ b/ext/phalcon.c
@@ -704,8 +704,9 @@ static ZEND_MODULE_POST_ZEND_DEACTIVATE_D(phalcon)
 	if (CG(unclean_shutdown)) {
 		zend_phalcon_globals *pg = PHALCON_VGLOBAL;
 
-		INIT_ZVAL(*pg->z_null);
+		INIT_PZVAL(pg->z_null);
 		Z_ADDREF_P(pg->z_null);
+		ZVAL_NULL(pg->z_null);
 
 		INIT_PZVAL(pg->z_false);
 		Z_ADDREF_P(pg->z_false);

--- a/unit-tests/AsyncTest.php
+++ b/unit-tests/AsyncTest.php
@@ -22,6 +22,11 @@ class AysncTest extends PHPUnit_Framework_TestCase
 {
 	public function test()
 	{
+		if (!function_exists('ftok') || !function_exists('pcntl_fork')) {
+			$this->markTestSkipped('Test skipped');
+			return;
+		}
+
 		Phalcon\Async::clear();
 
 		$id1 = Phalcon\Async::call(function () {

--- a/unit-tests/FilterTest.php
+++ b/unit-tests/FilterTest.php
@@ -22,6 +22,11 @@ class FilterTest extends PHPUnit_Framework_TestCase
 {
 	public function testXSS()
 	{
+		if (!class_exists('DOMDocument')) {
+			$this->markTestSkipped('Test skipped');
+			return;
+		}
+
 		$str = '<strong style="color:blue">Click</strong><div>name</div>';
 		$filter = new Phalcon\Filter;
 		$ret = $filter->sanitize('<strong style="color:blue" onclick="alert(\'clicked\')">Click</strong><div style="color:expression(1+1)">name</div>', 'xssclean');

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -435,6 +435,28 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(count($page->items) > 0);
 		$this->assertEquals($page->current, 1);
 		$this->assertTrue($page->total_pages > 0);
+
+		$bind_params = array('rawsql' => new Phalcon\Db\RawValue('tipo_documento_id=1'));
+		$bind_types = array('rawsql' => PDO::PARAM_STR);
+
+		$users = $di->modelsManager->createBuilder()->from('Personnes')->andwhere(":rawsql:", $bind_params, $bind_types);
+		$paginator = new \Phalcon\Paginator\Adapter\QueryBuilder(array(
+			"builder" => $users,
+			"limit" => 10,
+			"page" => 1
+		));
+		$page = $paginator->getPaginate();
+
+		$this->assertEquals($bind_params, array('rawsql' => new Phalcon\Db\RawValue('tipo_documento_id=1')));
+		$this->assertEquals($bind_types, array('rawsql' => PDO::PARAM_STR));
+
+		$bind_params = array('rawsql' => new Phalcon\Db\RawValue('tipo_documento_id=1'), 'estado' => 'A');
+		$bind_types = array('rawsql' => PDO::PARAM_STR , 'estado' => PDO::PARAM_STR);
+
+		$users = $di->modelsManager->executeQuery("SELECT * FROM Personnes WHERE :rawsql: AND estado = :estado: LIMIT 2", $bind_params, $bind_types);
+
+		$this->assertEquals($bind_params, array('rawsql' => new Phalcon\Db\RawValue('tipo_documento_id=1'), 'estado' => 'A'));
+		$this->assertEquals($bind_types, array('rawsql' => PDO::PARAM_STR , 'estado' => PDO::PARAM_STR));
 	}
 
 	public function testIssue2301()


### PR DESCRIPTION
```php
$arr = ['rawsql' => new Phalcon\Db\RawValue('sys=1')];
$arr2 = ['rawsql' => PDO::PARAM_STR ];

var_dump($arr, $arr2);
$users = $di->modelsManager->createBuilder()->from('Users')->andwhere(":rawsql:", $arr, $arr2);
$paginator = new \Phalcon\Paginator\Adapter\QueryBuilder(array(
		"builder" => $users,
		"limit" => 30,
		"page" => 1
));
$page = $paginator->getPaginate();
var_dump($arr, $arr2);

$users = $di->modelsManager->executeQuery("SELECT * FROM Users WHERE :rawsql: or sys = :sys: LIMIT 2", $arr, $arr2);
var_dump($arr, $arr2);
```